### PR TITLE
Fix typo?

### DIFF
--- a/lisp/apps/spookfox-jscl.el
+++ b/lisp/apps/spookfox-jscl.el
@@ -35,7 +35,7 @@ because emacs-lisp do not allow writing #j: forms, even in quoted
 form."
   (let ((client (cl-first spookfox--connected-clients))
         (str-form (string-replace "(js:" "(#j:" (prin1-to-string form))))
-    (case context
+    (cl-case context
       (background
        (when client
          (plist-get


### PR DESCRIPTION
I was getting this error on `spook-switch-tab`

![image](https://user-images.githubusercontent.com/15933322/227724045-d249ea0e-712b-4b73-8074-2a5daf19830e.png)
